### PR TITLE
Fix: Email verification token not encoding correctly

### DIFF
--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -50,6 +50,12 @@ authRouter.post("/register", async (req, res) => {
       return res.status(409).json({ error: "That username is already taken" });
     }
 
+    if (!(username && email && password)) {
+      return res
+        .status(400)
+        .json({ error: "Username, email or password is missing." });
+    }
+
     // Hash the password
     bcrypt.hash(password, 10, async (err, hash) => {
       if (err) throw err;

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -68,7 +68,7 @@ authRouter.post("/register", async (req, res) => {
         isVerified: false,
         isAdmin: false,
       };
-      const newUserId = await userCollection.insertOne(newUser);
+      const { newUserId } = await userCollection.insertOne(newUser);
 
       // Generate verification token
       const token = jwt.sign({ userId: newUserId }, secret_key, {

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -68,10 +68,9 @@ authRouter.post("/register", async (req, res) => {
         isVerified: false,
         isAdmin: false,
       };
-      const { newUserId } = await userCollection.insertOne(newUser);
-
+      const { insertedId } = await userCollection.insertOne(newUser);
       // Generate verification token
-      const token = jwt.sign({ userId: newUserId }, secret_key, {
+      const token = jwt.sign({ userId: insertedId }, secret_key, {
         expiresIn: "1d",
       });
 

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -62,10 +62,10 @@ authRouter.post("/register", async (req, res) => {
         isVerified: false,
         isAdmin: false,
       };
-      await userCollection.insertOne(newUser);
+      const newUserId = await userCollection.insertOne(newUser);
 
       // Generate verification token
-      const token = jwt.sign({ userId: newUser._id }, secret_key, {
+      const token = jwt.sign({ userId: newUserId }, secret_key, {
         expiresIn: "1d",
       });
 


### PR DESCRIPTION
Not 100% sure about the intent of wrapping the post-hash processes in the callback, so lemme know I've misunderstood and these were intentional design choices. 