### PR TITLE
Fix: Add missing space to follower number on profile page

### DIFF
--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -174,6 +174,7 @@ function UserProfile() {
                     {followStats.followingUser.toLocaleString()}
                   </span>
                   <span className="text-gray-600 dark:text-gray-400">
+                    {" "}
                     Followers
                   </span>
                 </Link>


### PR DESCRIPTION
- E.g., show `12 Followers` instead of `12Followers`.