### PR TITLE
Feature: Network Page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,7 @@ import EnterOTP from "./pages/EnterOTP";
 import UserProfile from "./pages/UserProfile";
 import Followers from "./pages/Followers";
 import Following from "./pages/Following";
+import Network from "./pages/Network";
 import SinglePost from "./pages/SinglePost";
 import NotificationsPage from "./pages/Notifications";
 
@@ -78,6 +79,7 @@ function App() {
                     <Route path="/profile/:id" element={<UserProfile />} />
                     <Route path="/user/:id/followers" element={<Followers />} />
                     <Route path="/user/:id/following" element={<Following />} />
+                    <Route path="/network" element={<Network />} />
                     <Route path="/post/:id" element={<SinglePost />} />
                     <Route
                       path="/notifications"

--- a/frontend/src/layouts/PrivateLayout.jsx
+++ b/frontend/src/layouts/PrivateLayout.jsx
@@ -19,7 +19,7 @@ export default function PrivateLayout() {
             text="Trending"
           />
         </div>
-        <div onClick={() => navigate("/followers")}>
+        <div onClick={() => navigate("/network")}>
           <SidebarItem icon={<Users className="h-6 w-6" />} text="Network" />
         </div>
         <div onClick={() => navigate("/profile/me")}>

--- a/frontend/src/pages/Network.jsx
+++ b/frontend/src/pages/Network.jsx
@@ -1,0 +1,200 @@
+import { useState, useEffect } from "react";
+import { getFollowersById, getFollowedById } from "../api/followersService.js";
+import _ from "lodash";
+import useAuth from "../hooks/useAuth.js";
+import UserInteractionButtons from "../components/UserInteractionButtons.jsx";
+
+import { Spinner, Card, Tabs } from "flowbite-react";
+
+function Network() {
+  const auth = useAuth();
+  const [loading, setLoading] = useState(true);
+  const [followers, setFollowers] = useState([]);
+  const [following, setFollowing] = useState([]);
+  const [viewerId, setViewerId] = useState();
+  const [activeTab, setActiveTab] = useState("followers");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const user = await auth.getUser();
+        setViewerId(user._id);
+        
+        // Fetch followers data
+        const followersResponse = await getFollowersById(user._id, user._id);
+        if (followersResponse.success !== false) {
+          setFollowers(followersResponse.data);
+        }
+        
+        // Fetch following data
+        const followingResponse = await getFollowedById(user._id, user._id);
+        if (followingResponse.success !== false) {
+          setFollowing(followingResponse.data);
+        }
+      } catch (error) {
+        console.error("Error fetching network data:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [auth]);
+
+  const onFollowerChange = (targetId, isFollow) => {
+    setFollowers((prev) => {
+      return prev.map((user) => {
+        if (user._id === targetId) {
+          return { ...user, isFollowing: isFollow };
+        }
+        return user;
+      });
+    });
+  };
+
+  const onFollowingChange = (targetId, isFollow) => {
+    setFollowing((prev) => {
+      return prev.map((user) => {
+        if (user._id === targetId) {
+          return { ...user, isFollowing: isFollow };
+        }
+        return user;
+      });
+    });
+  };
+
+  const handleTabChange = (tab) => {
+    setActiveTab(tab);
+  };
+
+  return loading ? (
+    <div className="p-16 text-center">
+      <Spinner aria-label="Loading network data" size="xl" />
+    </div>
+  ) : (
+    <div className="flex justify-center">
+      <Card className="mt-16 w-2/5 text-gray-900 dark:text-white">
+        <div className="mb-4">
+          <div className="border-b border-gray-200 dark:border-gray-700">
+            <ul className="flex flex-wrap -mb-px text-sm font-medium text-center">
+              <li className="mr-2">
+                <button
+                  onClick={() => handleTabChange("followers")}
+                  className={`inline-block p-4 border-b-2 rounded-t-lg ${
+                    activeTab === "followers"
+                      ? "text-blue-600 border-blue-600 dark:text-blue-500 dark:border-blue-500"
+                      : "border-transparent hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300"
+                  }`}
+                >
+                  Followers
+                </button>
+              </li>
+              <li className="mr-2">
+                <button
+                  onClick={() => handleTabChange("following")}
+                  className={`inline-block p-4 border-b-2 rounded-t-lg ${
+                    activeTab === "following"
+                      ? "text-blue-600 border-blue-600 dark:text-blue-500 dark:border-blue-500"
+                      : "border-transparent hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300"
+                  }`}
+                >
+                  Following
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="flow-root">
+          {activeTab === "followers" && (
+            <>
+              <h5 className="text-xl font-bold leading-none mb-4">Followers</h5>
+              {followers.length > 0 ? (
+                <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {followers.map((follower) => (
+                    <li key={follower._id} className="py-3 sm:py-4">
+                      <div className="flex items-center space-x-4">
+                        <a href={`/profile/${follower._id}`} className="shrink-0">
+                          <img
+                            className="h-auto w-16 rounded-full object-cover shadow-lg"
+                            src={follower?.profile_picture}
+                            alt="Profile"
+                          />
+                        </a>
+                        <div className="min-w-0 flex-1">
+                          <a
+                            href={`/profile/${follower._id}`}
+                            className="text-md font-semibold hover:underline"
+                          >
+                            @{follower.username}
+                          </a>
+                          <p className="text-sm font-normal italic text-gray-400">
+                            0 mutual friends
+                          </p>
+                        </div>
+
+                        <UserInteractionButtons
+                          viewerId={viewerId}
+                          targetId={follower._id}
+                          onFollowChange={onFollowerChange}
+                          isFollowing={follower.isFollowing}
+                        />
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p>No followers yet.</p>
+              )}
+            </>
+          )}
+
+          {activeTab === "following" && (
+            <>
+              <h5 className="text-xl font-bold leading-none mb-4">Following</h5>
+              {following.length > 0 ? (
+                <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {following.map((followed) => (
+                    <li key={followed._id} className="py-3 sm:py-4">
+                      <div className="flex items-center space-x-4">
+                        <a href={`/profile/${followed._id}`} className="shrink-0">
+                          <img
+                            className="h-auto w-16 rounded-full object-cover shadow-lg"
+                            src={followed?.profile_picture}
+                            alt="Profile"
+                          />
+                        </a>
+                        <div className="min-w-0 flex-1">
+                          <a
+                            href={`/profile/${followed._id}`}
+                            className="text-lg font-semibold hover:underline"
+                          >
+                            @{followed.username}
+                          </a>
+                          <p className="text-sm font-normal italic text-gray-400">
+                            0 mutual friends
+                          </p>
+                        </div>
+                        <UserInteractionButtons
+                          viewerId={viewerId}
+                          targetId={followed._id}
+                          onFollowChange={onFollowingChange}
+                          isFollowing={followed.isFollowing}
+                        />
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p>Not following anyone yet.</p>
+              )}
+            </>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default Network; 

--- a/frontend/src/pages/Network.jsx
+++ b/frontend/src/pages/Network.jsx
@@ -3,16 +3,21 @@ import { getFollowersById, getFollowedById } from "../api/followersService.js";
 import _ from "lodash";
 import useAuth from "../hooks/useAuth.js";
 import UserInteractionButtons from "../components/UserInteractionButtons.jsx";
+import { useSearchParams } from "react-router-dom";
 
 import { Spinner, Card, Tabs } from "flowbite-react";
 
 function Network() {
   const auth = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [loading, setLoading] = useState(true);
   const [followers, setFollowers] = useState([]);
   const [following, setFollowing] = useState([]);
   const [viewerId, setViewerId] = useState();
-  const [activeTab, setActiveTab] = useState("followers");
+  const [activeTab, setActiveTab] = useState(() => {
+    const tabParam = searchParams.get("tab");
+    return tabParam === "following" ? "following" : "followers";
+  });
 
   useEffect(() => {
     const fetchData = async () => {
@@ -42,6 +47,13 @@ function Network() {
     fetchData();
   }, [auth]);
 
+  useEffect(() => {
+    const tabParam = searchParams.get("tab");
+    if (tabParam === "following" || tabParam === "followers") {
+      setActiveTab(tabParam);
+    }
+  }, [searchParams]);
+
   const onFollowerChange = (targetId, isFollow) => {
     setFollowers((prev) => {
       return prev.map((user) => {
@@ -66,6 +78,7 @@ function Network() {
 
   const handleTabChange = (tab) => {
     setActiveTab(tab);
+    setSearchParams({ tab });
   };
 
   return loading ? (

--- a/frontend/src/pages/Network.jsx
+++ b/frontend/src/pages/Network.jsx
@@ -125,7 +125,7 @@ function Network() {
                         <div className="min-w-0 flex-1">
                           <a
                             href={`/profile/${follower._id}`}
-                            className="text-md font-semibold hover:underline"
+                            className="text-lg font-semibold hover:underline"
                           >
                             @{follower.username}
                           </a>

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -15,6 +15,7 @@ import UserInteractionButtons from "../components/UserInteractionButtons.jsx";
 import { getSafeObject } from "../util/defaultObjects.js";
 import DailyPostCounter from "../components/DailyPostCounter";
 import SuggestedUsers from "../components/SuggestedUsers.jsx";
+import Composer from "../components/Composer.jsx";
 
 function UserProfile() {
   const auth = useAuth();

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -147,7 +147,7 @@ function UserProfile() {
             <ul className="flex text-sm">
               <li className="me-2">
                 <Link
-                  to={`/user/${userData._id}/following`}
+                  to={`/network?tab=following`}
                   className="hover:underline"
                 >
                   <span
@@ -164,7 +164,7 @@ function UserProfile() {
               </li>
               <li>
                 <Link
-                  to={`/user/${userData._id}/followers`}
+                  to={`/network?tab=followers`}
                   className="hover:underline"
                 >
                   <span


### PR DESCRIPTION
I created a new Network page component that combines the existing Followers and Following views into a single page with tabs. Instead of separate pages, users can now switch between seeing their followers and who they're following by clicking tabs. I added a route for this page in App.jsx and updated the sidebar to point to this new page when users click on the Network icon. 