### PR TITLE
Fix: Profile followers/following navigation to show correct user's network

### DIFF
--- a/frontend/src/pages/Network.jsx
+++ b/frontend/src/pages/Network.jsx
@@ -26,14 +26,17 @@ function Network() {
         const user = await auth.getUser();
         setViewerId(user._id);
         
+        // Get userId from URL params or default to current user
+        const userId = searchParams.get("userId") || user._id;
+        
         // Fetch followers data
-        const followersResponse = await getFollowersById(user._id, user._id);
+        const followersResponse = await getFollowersById(userId, user._id);
         if (followersResponse.success !== false) {
           setFollowers(followersResponse.data);
         }
         
-        // Fetch following data
-        const followingResponse = await getFollowedById(user._id, user._id);
+        
+        const followingResponse = await getFollowedById(userId, user._id);
         if (followingResponse.success !== false) {
           setFollowing(followingResponse.data);
         }
@@ -45,7 +48,7 @@ function Network() {
     };
 
     fetchData();
-  }, [auth]);
+  }, [auth, searchParams]);
 
   useEffect(() => {
     const tabParam = searchParams.get("tab");
@@ -77,8 +80,16 @@ function Network() {
   };
 
   const handleTabChange = (tab) => {
+    // Preserve the userId parameter when changing tabs
+    const userId = searchParams.get("userId");
+    const newParams = { tab };
+    
+    if (userId) {
+      newParams.userId = userId;
+    }
+    
     setActiveTab(tab);
-    setSearchParams({ tab });
+    setSearchParams(newParams);
   };
 
   return loading ? (
@@ -210,4 +221,4 @@ function Network() {
   );
 }
 
-export default Network; 
+export default Network;

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -148,7 +148,7 @@ function UserProfile() {
             <ul className="flex text-sm">
               <li className="me-2">
                 <Link
-                  to={`/network?tab=following`}
+                  to={`/network?tab=following&userId=${userData._id}`}
                   className="hover:underline"
                 >
                   <span
@@ -165,7 +165,7 @@ function UserProfile() {
               </li>
               <li>
                 <Link
-                  to={`/network?tab=followers`}
+                  to={`/network?tab=followers&userId=${userData._id}`}
                   className="hover:underline"
                 >
                   <span


### PR DESCRIPTION
When viewing another user's profile and clicking on their "Followers" or "Following" links, the network page was incorrectly showing the current user's network instead of the profile owner's network. This fix ensures that the network page displays the correct user's followers and following lists by:

1. Adding the profile owner's ID as a URL parameter when navigating from their profile
2. Modifying the Network page to use the provided user ID from URL parameters
3. Preserving the user ID parameter when switching between followers and following tabs

Now users can properly view other users' network connections from their profiles.
