### PR TITLE
Fix: Remove erroneous profile page API call

### DIFF
--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -40,7 +40,7 @@ function UserProfile() {
   }, [auth]);
 
   const fetchUserData = useCallback(async () => {
-    if (!viewer) return;
+    if (!viewer || !viewer._id) return;
     setLoading(true);
     try {
       const profileUserId = paramId === "me" ? viewer._id : paramId;


### PR DESCRIPTION
- Previously was making a call to the followers API before it had determined the page viewer. This resulted in a API request with a missing parameter. Changed the conditions for the page loading so that this API call doesn't happen until the necessary states are set.