### PR TITLE
Fix: Add Unauthorised flow to pages that misbehave without login

### DIFF
--- a/frontend/src/pages/FeedFollowing.jsx
+++ b/frontend/src/pages/FeedFollowing.jsx
@@ -6,6 +6,7 @@ import useScrollingFeed from "../hooks/useScrollingFeed.js";
 
 import Post from "../components/Post.jsx";
 import Composer from "../components/Composer.jsx";
+import Unauthorised from "../components/Unauthorised.jsx";
 import FeedLayout from "../layouts/FeedLayout.jsx";
 
 import { getFollowingFeed } from "../api/feeds.js";
@@ -33,6 +34,8 @@ function Feed() {
       });
     }
   }, [auth]);
+
+  if (!auth.loggedIn) return <Unauthorised />;
 
   return (
     <FeedLayout viewer={viewer}>

--- a/frontend/src/pages/FeedLatest.jsx
+++ b/frontend/src/pages/FeedLatest.jsx
@@ -6,6 +6,7 @@ import useScrollingFeed from "../hooks/useScrollingFeed.js";
 
 import Post from "../components/Post.jsx";
 import Composer from "../components/Composer.jsx";
+import Unauthorised from "../components/Unauthorised.jsx";
 import FeedLayout from "../layouts/FeedLayout.jsx";
 
 import { getLatestFeed } from "../api/feeds.js";
@@ -28,6 +29,8 @@ function Feed() {
       });
     }
   }, [auth]);
+
+  if (!auth.loggedIn) return <Unauthorised />;
 
   return (
     <FeedLayout viewer={viewer}>

--- a/frontend/src/pages/Network.jsx
+++ b/frontend/src/pages/Network.jsx
@@ -25,6 +25,7 @@ function Network() {
       setLoading(true);
       try {
         const user = await auth.getUser();
+        if (!user) return;
         setViewerId(user._id);
 
         // Get userId from URL params or default to current user

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -5,6 +5,7 @@ import { Tabs, TabItem, Spinner, TextInput } from "flowbite-react";
 
 import Markdown from "react-markdown";
 
+import Unauthorised from "../components/Unauthorised";
 import UserInteractionButtons from "../components/UserInteractionButtons";
 import { getSearchResults } from "../api/searchService";
 import useAuth from "../hooks/useAuth";
@@ -180,6 +181,8 @@ function Search() {
       </div>
     </li>
   );
+
+  if (!auth.loggedIn) return <Unauthorised />;
 
   return (
     <div className="mx-auto mb-4 flex max-w-3xl flex-col gap-5">

--- a/frontend/src/pages/SinglePost.jsx
+++ b/frontend/src/pages/SinglePost.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import Post from "../components/Post";
+import Unauthorised from "../components/Unauthorised";
 import useAuth from "../hooks/useAuth";
 import { getPostById } from "../api/postService";
 import { useCacheUpdater } from "../hooks/useUserCache";
@@ -39,6 +40,8 @@ function SinglePost() {
     fetchUser();
     fetchPostDate();
   }, [auth, fetchPostDate]);
+
+  if (!auth.loggedIn) return <Unauthorised />;
 
   if (!post) {
     return <div>Sorry! This post doesn't exist</div>;

--- a/frontend/src/pages/Trending.jsx
+++ b/frontend/src/pages/Trending.jsx
@@ -1,5 +1,12 @@
 import TrendingTags from "../components/TrendingTags";
+import Unauthorised from "../components/Unauthorised";
+import useAuth from "../hooks/useAuth";
+
 export default function Trending() {
+  const auth = useAuth();
+
+  if (!auth.loggedIn) return <Unauthorised />;
+
   return (
     <div className="mx-auto flex w-full justify-center">
       <TrendingTags className="w-full" />


### PR DESCRIPTION
Fixed some auth flow. Some behave a bit erroneously when not logged in. Show 'Unauthorised' if they are not logged in to prevent these errors.

**Pages changed**:
- FeedFollowing
- FeedLatest
- Search
- SinglePost
- Trending

Also fixed bug with Network page making a bad API call when not logged in.