### PR TITLE
Fix: Grayscale stuck at 100% when LocalStorage not initialised

### DIFF
--- a/frontend/src/components/Timer.jsx
+++ b/frontend/src/components/Timer.jsx
@@ -41,6 +41,7 @@ function Timer() {
   // Update grayscale effect based on remaining time
   useEffect(() => {
     const halfWay = totalTimeInSeconds / 2;
+    if (isNaN(timeRemaining)) return;
     setGrayscale(timeRemaining >= halfWay ? thresholdFraction : 1);
   }, [timeRemaining, setGrayscale]);
 


### PR DESCRIPTION
When local storage is not initialised, the time remaining is `NaN`. This causes the useEffect in `Timer.jsx` to set the grayscale to 1 (the max grayscale amount) due to this ternary:

```js
setGrayscale(timeRemaining >= halfWay ? thresholdFraction : 1);
```

Added a single line before this to return early if `timeRemaining` is `NaN`:

```js
useEffect(() => {
  const halfWay = totalTimeInSeconds / 2;
  if (isNaN(timeRemaining)) return;
  setGrayscale(timeRemaining >= halfWay ? thresholdFraction : 1);
}, [timeRemaining, setGrayscale]);
```

Just a simple workaround for now, the Timer and Grayscale system ideally needs a refactor.